### PR TITLE
Header-Only fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,9 +251,9 @@ python: .check_python $(python_dir)/aabb.i $(python_dir)/setup.py
 .PHONY: header-only
 header-only: $(headers) $(sources)
 	mkdir -p $(header_only_dir)
-	head --lines=-3 src/AABB.h > $(header_only_lib)
+	head --lines=-2 src/AABB.h > $(header_only_lib)
 	echo >> $(header_only_lib)
-	tail --lines=+31 src/AABB.cc >> $(header_only_lib)
+	tail --lines=+29 src/AABB.cc >> $(header_only_lib)
 	echo >> $(header_only_lib)
 	echo "#endif /* _AABB_H */" >> $(header_only_lib)
 


### PR DESCRIPTION
Fixed the line cutoffs. In the original version, the closing bracket for the aabb namespace in the headerfile was cutoff and the definition of MAX_DIMENSIONS was cut out of the cc file as well.