### PR TITLE
support for higher dimensional AABB trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ CXX := g++
 PREFIX := /usr/local
 
 # Python version
-PYTHON := 2.7
+#PYTHON := 2.7
+PYTHON := 3.6
 
 # External libraries.
 LIBS :=

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ CXX := g++
 PREFIX := /usr/local
 
 # Python version
-#PYTHON := 2.7
-PYTHON := 3.6
+PYTHON := 2.7
 
 # External libraries.
 LIBS :=

--- a/src/AABB.cc
+++ b/src/AABB.cc
@@ -490,7 +490,7 @@ namespace aabb
     }
 
     bool Tree::updateParticle(unsigned int particle, std::vector<double>& position, double radius,
-                              bool alwaysReinsert=false)
+                              bool alwaysReinsert)
     {
         // Validate the dimensionality of the position vector.
         if (position.size() != dimension)
@@ -514,7 +514,7 @@ namespace aabb
     }
 
     bool Tree::updateParticle(unsigned int particle, std::vector<double>& lowerBound,
-                              std::vector<double>& upperBound, bool alwaysReinsert=false)
+                              std::vector<double>& upperBound, bool alwaysReinsert)
     {
         // Validate the dimensionality of the bounds vectors.
         if ((lowerBound.size() != dimension) && (upperBound.size() != dimension))
@@ -558,9 +558,9 @@ namespace aabb
         // Create the new AABB.
         AABB aabb(lowerBound, upperBound);
 
+        
         // No need to update if the particle is still within its fattened AABB.
-        // TODO: maybe make this optional?
-        //if (nodes[node].aabb.contains(aabb)) return false;
+        if (!alwaysReinsert && nodes[node].aabb.contains(aabb)) return false;
 
         // Remove the current leaf.
         removeLeaf(node);

--- a/src/AABB.cc
+++ b/src/AABB.cc
@@ -489,7 +489,8 @@ namespace aabb
         particleMap.clear();
     }
 
-    bool Tree::updateParticle(unsigned int particle, std::vector<double>& position, double radius)
+    bool Tree::updateParticle(unsigned int particle, std::vector<double>& position, double radius,
+                              bool alwaysReinsert=false)
     {
         // Validate the dimensionality of the position vector.
         if (position.size() != dimension)
@@ -509,10 +510,11 @@ namespace aabb
         }
 
         // Update the particle.
-        return updateParticle(particle, lowerBound, upperBound);
+        return updateParticle(particle, lowerBound, upperBound, alwaysReinsert);
     }
 
-    bool Tree::updateParticle(unsigned int particle, std::vector<double>& lowerBound, std::vector<double>& upperBound)
+    bool Tree::updateParticle(unsigned int particle, std::vector<double>& lowerBound,
+                              std::vector<double>& upperBound, bool alwaysReinsert=false)
     {
         // Validate the dimensionality of the bounds vectors.
         if ((lowerBound.size() != dimension) && (upperBound.size() != dimension))

--- a/src/AABB.h
+++ b/src/AABB.h
@@ -33,7 +33,6 @@
 #include <iostream>
 #include <limits>
 #include <map>
-#include <stdexcept>
 #include <vector>
 
 /// Null node flag.
@@ -98,11 +97,13 @@ namespace aabb
         //! Test whether the AABB overlaps this one.
         /*! \param aabb
                 A reference to the AABB.
+            \param touchIsOverlap
+                Does touching constitute an overlap?
 
             \return
                 Whether the AABB overlaps.
          */
-        bool overlaps(const AABB&) const;
+        bool overlaps(const AABB&, bool touchIsOverlap) const;
 
         //! Compute the centre of the AABB.
         /*! \returns
@@ -195,8 +196,12 @@ namespace aabb
 
             \param nParticles
                 The number of particles (for fixed particle number systems).
+
+            \param touchIsOverlap
+                Does touching count as overlapping in query operations?
          */
-        Tree(unsigned int dimension_= 3, double skinThickness_ = 0.05, unsigned int nParticles = 16);
+        Tree(unsigned int dimension_= 3, double skinThickness_ = 0.05, unsigned int nParticles = 16,
+             bool touchIsOverlap=true);
 
         //! Constructor (custom periodicity).
         /*! \param dimension_
@@ -214,8 +219,12 @@ namespace aabb
 
             \param nParticles
                 The number of particles (for fixed particle number systems).
+
+            \param touchIsOverlap
+                Does touching count as overlapping in query operations?
          */
-        Tree(unsigned int, double, const std::vector<bool>&, const std::vector<double>&, unsigned int nParticles = 16);
+        Tree(unsigned int, double, const std::vector<bool>&, const std::vector<double>&, unsigned int nParticles = 16,
+            bool touchIsOverlap=true);
 
         //! Set the periodicity of the simulation box.
         /*! \param periodicity_
@@ -400,6 +409,9 @@ namespace aabb
 
         /// A map between particle and node indices.
         std::map<unsigned int, unsigned int> particleMap;
+
+        /// Does touching count as overlapping in tree queries?
+        bool touchIsOverlap;
 
         //! Allocate a new node.
         /*! \return

--- a/src/AABB.h
+++ b/src/AABB.h
@@ -306,7 +306,7 @@ namespace aabb
                 Always reinsert the particle, even if it's within its old AABB (default: false)
 
          */
-        bool updateParticle(unsigned int, std::vector<double>&, std::vector<double>&, , bool alwaysReinsert=false);
+        bool updateParticle(unsigned int, std::vector<double>&, std::vector<double>&, bool alwaysReinsert=false);
 
         //! Query the tree to find candidate interactions for a particle.
         /*! \param particle

--- a/src/AABB.h
+++ b/src/AABB.h
@@ -284,10 +284,13 @@ namespace aabb
             \param radius
                 The radius of the particle.
 
+            \param alwaysReinsert
+                Always reinsert the particle, even if it's within its old AABB (default:false)
+
             \return
                 Whether the particle was reinserted.
          */
-        bool updateParticle(unsigned int, std::vector<double>&, double);
+        bool updateParticle(unsigned int, std::vector<double>&, double, bool alwaysReinsert=false);
 
         //! Update the tree if a particle moves outside its fattened AABB.
         /*! \param particle
@@ -299,8 +302,11 @@ namespace aabb
             \param upperBound
                 The upper bound in each dimension.
 
+            \param alwaysReinsert
+                Always reinsert the particle, even if it's within its old AABB (default: false)
+
          */
-        bool updateParticle(unsigned int, std::vector<double>&, std::vector<double>&);
+        bool updateParticle(unsigned int, std::vector<double>&, std::vector<double>&, , bool alwaysReinsert=false);
 
         //! Query the tree to find candidate interactions for a particle.
         /*! \param particle

--- a/src/AABB.h
+++ b/src/AABB.h
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <stdexcept>
 #include <vector>
 
 /// Null node flag.


### PR DESCRIPTION
This pull request has 3 changes:

- support for AABB trees for any number of dimensions >= 2 (previous code is limited to 2 or 3)
- added a `touchIsOverlap` parameter to specify if touching boxes should be considered overlapping (default is `true`, which matches the existing implementation)
- added a `alwaysReinsert` argument to `updateParticle` which forces the particle to always be removed and reinserted, rather than only doing this if the particle leaves its fattened AABB (default is `false`, which matches the existing implementation)