### PR TITLE
relaxed aabb lower bound check

### DIFF
--- a/src/AABB.cc
+++ b/src/AABB.cc
@@ -53,7 +53,7 @@ namespace aabb
         for (unsigned int i=0;i<lowerBound.size();i++)
         {
             // Validate the bound.
-            if (lowerBound[i] >= upperBound[i])
+            if (lowerBound[i] > upperBound[i])
             {
                 throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
             }
@@ -401,7 +401,7 @@ namespace aabb
         for (unsigned int i=0;i<dimension;i++)
         {
             // Validate the bound.
-            if (lowerBound[i] >= upperBound[i])
+            if (lowerBound[i] > upperBound[i])
             {
                 throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
             }
@@ -547,7 +547,7 @@ namespace aabb
         for (unsigned int i=0;i<dimension;i++)
         {
             // Validate the bound.
-            if (lowerBound[i] >= upperBound[i])
+            if (lowerBound[i] > upperBound[i])
             {
                 throw std::invalid_argument("[ERROR]: AABB lower bound is greater than the upper bound!");
             }


### PR DESCRIPTION
AABB's would throw an exception if the upper bound was ever equal to lower bound. I think this should be allowed.

The only reason I can think of where this might cause problems would be in computing the surface area, where if two of the dimensions have width zero, the surface area would be zero. But that's a rare case, and it's only a performance issue when it does happen.

With this change, the bounds are relaxed and you can, for example, insert points into the AABB tree.