### PR TITLE
Fixed: overlap invalid construct

### DIFF
--- a/src/AABB.cc
+++ b/src/AABB.cc
@@ -246,7 +246,6 @@ namespace aabb
 
         // Initialise the tree.
         root = NULL_NODE;
-        touchIsOverlap = true;
         nodeCount = 0;
         nodeCapacity = nParticles;
         nodes.resize(nodeCapacity);


### PR DESCRIPTION
1.  Redundant assignment makes touchIsOverlap invalid.
